### PR TITLE
Added libduckdb.dylib and updated changelog

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# 0.1.4
+
+- Fixed missing library for MacOS support by adding `libduckdb.dylib`
+
 # 0.1.3
 
 - Check for null in `psduckdb` after `Read-Host`.

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@
 # 0.1.3
 
 - Check for null in `psduckdb` after `Read-Host`.
-- Ensure output is written to the console in `Invoke-PSDuckDb.ps1`.
+- Ensure output igs written to the console in `Invoke-PSDuckDb.ps1`.
 
 # 0.1.2
 


### PR DESCRIPTION
Added `libduckdb.dylib` for MacOS support

The downside of the fix is that adding the library for each individual OS will result in longer download times.

An alternative solutions could be:
* To determine the OS on module load, or module first load, and verify that the download the libraries then
* Add error handling, when dll is not found with error message: `Unable to load shared library 'duckdb' or one of its dependencies.`, download the file(s) and rerun the previous command.

Additionally, because this is an unsigned file, I first had to manually click to open this file before it was allowed to load because of the `[Apple can't check app for malicious software](https://support.apple.com/en-gb/guide/mac-help/mchleab3a043/mac)` message. I have not investigated if there's a programmatic solution for this as of yet.